### PR TITLE
feat: add ability to pass values to package process

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This maker takes two configuration objects: `codesigning` for codesigning and `u
   - `updaterCacheDirName`: Name of the local cache. By default `${name}-updater`.
   - `channel`: Name of the update channel. By default `latest`.
   - `publisherName`: Used to verify the code signature. 
+- `packageOptions`: Options passed to [@electron-userland/electron-builder](https://www.electron.build/configuration/configuration#configuration) for the package step.
 
 ```ts
 // forge.config.js with minimal configuration
@@ -33,11 +34,14 @@ makers: [
           certificatePassword?: string;
         },
         updater: {
-					url: "https://s3-us-west-2.amazonaws.com/my-bucket",
-					updaterCacheDirName: "my-updater",
+          url: "https://s3-us-west-2.amazonaws.com/my-bucket",
+          updaterCacheDirName: "my-updater",
           channel: "latest",
           publisherName: "My Company, Inc."
-				}
+        },
+        packageOptions: {
+          copyright: "My Company, Inc."
+        }
       },
     }
   ]

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { SignOptions } from 'electron-windows-sign';
+import { PackagerOptions } from "app-builder-lib";
 
 export type CodesignOptions = Omit<SignOptions, 'appDirectory'>
 
@@ -10,4 +11,5 @@ export interface MakerNSISConfig {
     updaterCacheDirName?: string,
     publisherName?: string
   }
+  packageOptions?: PackagerOptions;
 }

--- a/src/makerNsis.ts
+++ b/src/makerNsis.ts
@@ -102,7 +102,7 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 
     // Actually make the NSIS
     log(`Calling app-builder-lib's buildForge() with ${tmpPath}`);
-    const output = await buildForge({ dir: tmpPath }, { win: [`nsis:${options.targetArch}`] });
+    const output = await buildForge({ dir: tmpPath }, { ...this.config.packageOptions, win: [`nsis:${options.targetArch}`] });
 
     // Move the output to the actual output folder, app-builder-lib might get it wrong
     log('Received output files', output);


### PR DESCRIPTION
This PR enables us to pass values to the configuration of the packaging process. In particular, I wanted to change the `config.nsis.installerIcon` and this PR allowed me to do that.