### PR TITLE
Upgrade windows-sign to 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "app-builder-lib": "^24.13.3",
     "debug": "^4.3.7",
     "electron-updater-yaml": "^1.1.2",
-    "electron-windows-sign": "^1.0.0",
+    "@electron/windows-sign": "^1.2.0",
     "fs-extra": "^11.2.0"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { SignOptions } from 'electron-windows-sign';
+import { SignOptions } from '@electron/windows-sign';
 
 export type CodesignOptions = Omit<SignOptions, 'appDirectory'>
 

--- a/src/makerNsis.ts
+++ b/src/makerNsis.ts
@@ -1,5 +1,5 @@
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
-import { sign } from 'electron-windows-sign';
+import { sign } from '@electron/windows-sign';
 import { buildForge } from 'app-builder-lib';
 import fs from 'fs-extra';
 import path from 'path';
@@ -24,7 +24,7 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
       try {
         await sign({ ...this.config.codesign, appDirectory: outPath });
       } catch (error) {
-        console.error('Failed to codesign using electron-windows-sign. Check your config and the output for details!', error);
+        console.error('Failed to codesign using @electron/windows-sign. Check your config and the output for details!', error);
         throw error;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,6 +199,17 @@
     minimist "^1.2.8"
     postject "^1.0.0-alpha.6"
 
+"@electron/windows-sign@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@electron/windows-sign/-/windows-sign-1.2.0.tgz#d4fe32f05b33070e3d9d45cfa899d4342b997f99"
+  integrity sha512-5zfLHfD6kGgsXzuYlKwlWWO8w6dboKy4dhd7rGnR4rQYumuDgPAF2TYjEa8LUi89KdHxtDy2btq02KvbjhK9Iw==
+  dependencies:
+    cross-dirname "^0.1.0"
+    debug "^4.3.4"
+    fs-extra "^11.1.1"
+    minimist "^1.2.8"
+    postject "^1.0.0-alpha.6"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
@@ -1245,15 +1256,6 @@ electron-updater-yaml@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/electron-updater-yaml/-/electron-updater-yaml-1.1.2.tgz"
   integrity sha512-rxlWK50wntisM2MkoyRMKNi31LO5PZuVgL5QVTTafuCkCWNEh+m/MfwAXL5dcrgDOMcj8aTUiAsCFcdOOkG+Tw==
-
-electron-windows-sign@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/electron-windows-sign/-/electron-windows-sign-1.0.0.tgz"
-  integrity sha512-PHg0Ip+PZKs8jSqjwJIASQhefpD+e7ezUdn/moROF+lOikRDeFO64ROFxKDy5V9mEOidOP9WHIH+gigx+NVvrQ==
-  dependencies:
-    debug "^4.3.4"
-    fs-extra "^11.1.1"
-    minimist "^1.2.8"
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This should allow signing with Azure Trusted Signing and also fixes #3. Tested with tsc to make sure the imports are fixed up correctly