### PR TITLE
Don't set Windows signing env variables if we don't need to

### DIFF
--- a/src/makerNsis.ts
+++ b/src/makerNsis.ts
@@ -30,12 +30,12 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 
       // Setup signing. If these variables are set, app-builder-lib will actually
       // codesign.
-      if (!process.env.CSC_LINK) {
+      if (!process.env.CSC_LINK && this.config.codesign.certificateFile) {
         log(`Setting process.env.CSC_LINK to ${this.config.codesign.certificateFile}`);
         process.env.CSC_LINK = this.config.codesign.certificateFile;
       }
 
-      if (!process.env.CSC_KEY_PASSWORD) {
+      if (!process.env.CSC_KEY_PASSWORD && this.config.codesign.certificatePassword) {
         log('Setting process.env.CSC_KEY_PASSWORD to the passed password');
         process.env.CSC_KEY_PASSWORD = this.config.codesign.certificatePassword;
       }


### PR DESCRIPTION
It seems from Issues like [this one](https://github.com/electron-userland/electron-builder/issues/5514) that having a set but empty environment variable for either `CSC_LINK` or `CSC_KEY_PASSWORD` makes winPackager sad. We might not want to set these variables if we're signing with Azure Trusted Signing or something else that doesn't use an on-disk cert. 

Build is running now to make sure that this actually works!